### PR TITLE
Fix composer install command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: composer
     volumes:
       - ./:/app
-    command: composer install
+    command: composer install --ignore-platform-reqs 
   luya_db:
     image: mysql:5.7
     command:


### PR DESCRIPTION
Fix the composer install issue caused by the php version used in the composer docker image is higher than the luya_web.

### What are you changing/introducing
When doing a fresh install using docker-compose, composer fails to install dependencies with this error :
...
    - phpspec/prophecy 1.13.0 requires php ^7.2 || ~8.0, <8.1 -> your php version (8.1.3) does not satisfy that requirement.
...

### What is the reason for changing/introducing
Looks that latest composer php version is conflicitng with some dependencies requirement causing composer install to fail.
Adding the --ignore-platform-reqs fixes the issue.


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
